### PR TITLE
fix(hook): add boolean types to set() and state

### DIFF
--- a/src/use-toggle.ts
+++ b/src/use-toggle.ts
@@ -4,7 +4,7 @@ export type UseToggleReturnType = {
   state: boolean;
   disable: () => void;
   enable: () => void;
-  set: (newState?: unknown) => void;
+  set: (newState: boolean) => void;
   toggle: () => void;
 };
 
@@ -26,11 +26,11 @@ export type UseToggleType = (initialState?: boolean) => UseToggleReturnType;
  * ```
  */
 export const useToggle: UseToggleType = (initalState = false) => {
-  const [state, setState] = React.useState(() => Boolean(initalState));
+  const [state, setState] = React.useState<boolean>(initalState);
 
   const disable = React.useCallback(() => setState(false), []);
   const enable = React.useCallback(() => setState(true), []);
-  const set = React.useCallback((newState: unknown) => setState(Boolean(newState)), []);
+  const set = React.useCallback((newState: boolean) => setState(newState), []);
   const toggle = React.useCallback(() => setState((prev) => !prev), []);
 
   return { state, disable, enable, set, toggle };


### PR DESCRIPTION
it's better to add strict type to `set()` to avoiding confusion for who uses it. 
It will be weird if the `set` value filled with string or anything and `Boolean()` it out, its better outside of the hooks.